### PR TITLE
com.utilities.buildpipeline 1.2.4

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
@@ -207,6 +207,15 @@ namespace Utilities.Editor.BuildPipeline
                         break;
                     case "-export":
                         IsExport = true;
+#if PLATFORM_STANDALONE_WIN
+                        UnityEditor.WindowsStandalone.UserBuildSettings.createSolution = true;
+#endif
+                        break;
+                    case "-symlinkSources":
+                        EditorUserBuildSettings.symlinkSources = true;
+                        break;
+                    case "-disableDebugging":
+                        EditorUserBuildSettings.allowDebugging = false;
                         break;
                 }
             }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
@@ -1,0 +1,53 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+#if UNITY_STANDALONE_OSX
+using System;
+using UnityEditor.OSXStandalone;
+#endif
+
+
+namespace Utilities.Editor.BuildPipeline
+{
+    public class MacOSBuildInfo : BuildInfo
+    {
+        public override BuildTarget BuildTarget => BuildTarget.StandaloneOSX;
+
+        public override string ExecutableFileExtension => ".app";
+
+        public override void ParseCommandLineArgs()
+        {
+            base.ParseCommandLineArgs();
+#if UNITY_STANDALONE_OSX
+            var arguments = Environment.GetCommandLineArgs();
+
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                switch (arguments[i])
+                {
+                    case "-export":
+                        UserBuildSettings.createXcodeProject = true;
+                        break;
+                    case "-arch"
+                        var arch = arguments[++i];
+
+                        switch (arch)
+                        {
+                            case "x64":
+                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.x64;
+                                break;
+                            case "ARM64":
+                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.ARM64;
+                                break;
+                            case "x64ARM64":
+                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.x64ARM64;
+                                break;
+                            default:
+                                throw new Exception($"Unsupported architecture: {arch}");
+                        }
+                }
+            }
+#endif
+        }
+    }
+}

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
@@ -28,23 +28,16 @@ namespace Utilities.Editor.BuildPipeline
                     case "-export":
                         UserBuildSettings.createXcodeProject = true;
                         break;
-                    case "-arch"
+                    case "-arch":
                         var arch = arguments[++i];
-
-                        switch (arch)
+                        UserBuildSettings.architecture = arch switch
                         {
-                            case "x64":
-                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.x64;
-                                break;
-                            case "ARM64":
-                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.ARM64;
-                                break;
-                            case "x64ARM64":
-                                UserBuildSettings.architecture = UnityEditor.Build.OSArchitecture.x64ARM64;
-                                break;
-                            default:
-                                throw new Exception($"Unsupported architecture: {arch}");
-                        }
+                            "x64" => MacOSArchitecture.x64,
+                            "ARM64" => MacOSArchitecture.ARM64,
+                            "x64ARM64" => MacOSArchitecture.x64ARM64,
+                            _ => throw new Exception($"Unsupported architecture: {arch}"),
+                        };
+                        break;
                 }
             }
 #endif

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs.meta
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54eded4985c128d49b6bae2857ca0377
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -16,7 +16,7 @@ using Debug = UnityEngine.Debug;
 namespace Utilities.Editor.BuildPipeline
 {
     /// <summary>
-    /// Cross platform player build tools
+    /// Cross-platform player build tools
     /// </summary>
     public class UnityPlayerBuildTools : IPreprocessBuildWithReport, IPostprocessBuildWithReport
     {
@@ -45,17 +45,18 @@ namespace Utilities.Editor.BuildPipeline
                 {
                     switch (currentBuildTarget)
                     {
-                        // TODO: Add additional platform specific build info classes
-                        //case BuildTarget.StandaloneOSX:
-                        //    break;
-                        //case BuildTarget.StandaloneWindows:
-                        //    break;
-                        //case BuildTarget.iOS:
-                        //    break;
                         case BuildTarget.Android:
                             buildInfoInstance = new AndroidBuildInfo();
                             break;
+                        case BuildTarget.StandaloneOSX:
+                            buildInfoInstance = new MacOSBuildInfo();
+                            break;
+                        // TODO: Add additional platform specific build info classes as needed
+                        //case BuildTarget.StandaloneWindows:
                         //case BuildTarget.StandaloneWindows64:
+                        //    break;
+                        //case BuildTarget.iOS:
+                        //    break;
                         //    break;
                         //case BuildTarget.WebGL:
                         //    break;

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.2.3",
+  "version": "1.2.4",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- make sure to export native code projects on export
- added additional command line args
  - disableDebugger
  - symlinkSources
- added MacOSBuildInfo