### PR TITLE
com.utilities.buildpipeline 1.2.6

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
@@ -33,9 +33,9 @@ namespace Utilities.Editor.BuildPipeline
                         UserBuildSettings.architecture = arch switch
                         {
 #if UNITY_2022_1_OR_NEWER
-                            "x86" => UnityEditor.Build.OSArchitecture.x86,
                             "x64" => UnityEditor.Build.OSArchitecture.x64,
                             "ARM64" => UnityEditor.Build.OSArchitecture.ARM64,
+                            "x64ARM64" => UnityEditor.Build.OSArchitecture.x64ARM64,
 #else
                             "x64" => MacOSArchitecture.x64,
                             "ARM64" => MacOSArchitecture.ARM64,

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.2.5",
+  "version": "1.2.6",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- Fix missing x64arm64 arch target for macOS