### PR TITLE
com.utilities.buildpipeline 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-buildOutputDirectory` | Sets the output directory for the build. |
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
-| `-buildConfiguration` | Sets the build configuration of the application, if the provided configuration string is `debug`, `master`, or `release`. |
+| `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |
 | `-export` | Creates a native code project for the target platform. |
 | `-symlinkSources` | Enables the use of symbolic links for the sources. |
 | `-disableDebugging` | Disables the ability to attach remote debuggers to the player. |
+| `-dotnetApiCompatibilityLevel` | Sets the dotnet api compatibility level of the player. Can be: `NET_2_0`, `NET_2_0_Subset`, `NET_4_6`, `NET_Unity_4_8`, `NET_Web`, `NET_Micro`, `NET_Standard`, or `NET_Standard_2_0`. |
+| `-scriptingBackend` | Sets the scripting framework of the player. Can be: `Mono2x`, `IL2CPP`, or `WinRTDotNET`. |
 
 #### Platform specific Command Line Arguments
 
@@ -130,10 +132,10 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-splitApk` | Uses APK expansion files. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-keystorePass` | Sets the keystore password. |
-| `-symbols` | Sets the symbol creation mode. Can be `public`, `debugging`, or `disabled`. |
+| `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
 
 ##### MacOS COmmand Line Arguments
 
 | Argument | Description |
 | -------- | ----------- |
-| `-arch` | Sets the build architecture. Can be `x64`, `arm64`, or `x64arm64`. |
+| `-arch` | Sets the build architecture. Can be: `x64`, `arm64`, or `x64arm64`. |

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -115,10 +115,12 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-buildOutputDirectory` | Sets the output directory for the build. |
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
-| `-buildConfiguration` | Sets the build configuration of the application, if the provided configuration string is `debug`, `master`, or `release`. |
+| `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |
 | `-export` | Creates a native code project for the target platform. |
 | `-symlinkSources` | Enables the use of symbolic links for the sources. |
 | `-disableDebugging` | Disables the ability to attach remote debuggers to the player. |
+| `-dotnetApiCompatibilityLevel` | Sets the dotnet api compatibility level of the player. Can be: `NET_2_0`, `NET_2_0_Subset`, `NET_4_6`, `NET_Unity_4_8`, `NET_Web`, `NET_Micro`, `NET_Standard`, or `NET_Standard_2_0`. |
+| `-scriptingBackend` | Sets the scripting framework of the player. Can be: `Mono2x`, `IL2CPP`, or `WinRTDotNET`. |
 
 #### Platform specific Command Line Arguments
 
@@ -130,10 +132,10 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-splitApk` | Uses APK expansion files. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-keystorePass` | Sets the keystore password. |
-| `-symbols` | Sets the symbol creation mode. Can be `public`, `debugging`, or `disabled`. |
+| `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
 
 ##### MacOS COmmand Line Arguments
 
 | Argument | Description |
 | -------- | ----------- |
-| `-arch` | Sets the build architecture. Can be `x64`, `arm64`, or `x64arm64`. |
+| `-arch` | Sets the build architecture. Can be: `x64`, `arm64`, or `x64arm64`. |

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
@@ -50,6 +50,9 @@ namespace Utilities.Editor.BuildPipeline
         public virtual BuildTarget BuildTarget { get; } = EditorUserBuildSettings.activeBuildTarget;
 
         /// <inheritdoc />
+        public virtual BuildTargetGroup BuildTargetGroup { get; } = EditorUserBuildSettings.selectedBuildTargetGroup;
+
+        /// <inheritdoc />
         public bool IsCommandLine { get; } = Application.isBatchMode;
 
         private string outputDirectory;
@@ -147,7 +150,7 @@ namespace Utilities.Editor.BuildPipeline
             {
                 switch (arguments[i])
                 {
-                    case "-ignoreCompilerErrors":
+                    case "-ignorecompilererrors":
                         CILoggingUtility.LoggingEnabled = false;
                         break;
                     case "-autoIncrement":
@@ -204,7 +207,7 @@ namespace Utilities.Editor.BuildPipeline
                                 Configuration = configuration;
                                 break;
                             default:
-                                Debug.LogError($"Failed to parse -buildConfiguration: {configuration}");
+                                Debug.LogError($"Failed to parse -buildConfiguration: \"{configuration}\"");
                                 break;
                         }
 
@@ -219,6 +222,39 @@ namespace Utilities.Editor.BuildPipeline
                         break;
                     case "-disableDebugging":
                         EditorUserBuildSettings.allowDebugging = false;
+                        break;
+                    case "-dotnetApiCompatibilityLevel":
+                        var apiCompatibilityLevelString = arguments[++i];
+
+                        if (Enum.TryParse(apiCompatibilityLevelString, true, out ApiCompatibilityLevel apiCompatibility))
+                        {
+                            PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup, apiCompatibility);
+                        }
+                        else
+                        {
+                            Debug.LogError($"Failed to parse -dotnetApiCompatibilityLevel: \"{apiCompatibilityLevelString}\"");
+                        }
+
+                        break;
+                    case "-scriptingBackend":
+                        var scriptingBackendString = arguments[++i][1..].ToLower();
+
+                        switch (scriptingBackendString)
+                        {
+                            case "mono":
+                                PlayerSettings.SetScriptingBackend(BuildTargetGroup, ScriptingImplementation.Mono2x);
+                                break;
+                            case "il2cpp":
+                                PlayerSettings.SetScriptingBackend(BuildTargetGroup, ScriptingImplementation.IL2CPP);
+                                break;
+                            case "winrt":
+                                PlayerSettings.SetScriptingBackend(BuildTargetGroup, ScriptingImplementation.WinRTDotNET);
+                                break;
+                            default:
+                                Debug.LogError($"Unsupported -scriptingBackend: \"{scriptingBackendString}\"");
+                                break;
+                        }
+
                         break;
                 }
             }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/IBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/IBuildInfo.cs
@@ -85,6 +85,11 @@ namespace Utilities.Editor.BuildPipeline
         BuildTarget BuildTarget { get; }
 
         /// <summary>
+        /// The build target group;
+        /// </summary>
+        BuildTargetGroup BuildTargetGroup { get; }
+
+        /// <summary>
         /// Optional parameter to set the player's <see cref="ColorSpace"/>
         /// </summary>
         ColorSpace? ColorSpace { get; set; }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
@@ -13,6 +13,9 @@ namespace Utilities.Editor.BuildPipeline
         public override BuildTarget BuildTarget => BuildTarget.Android;
 
         /// <inheritdoc />
+        public override BuildTargetGroup BuildTargetGroup => BuildTargetGroup.Android;
+
+        /// <inheritdoc />
         public override string ExecutableFileExtension => ".apk";
 
         /// <inheritdoc />

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/MacOSBuildInfo.cs
@@ -11,16 +11,23 @@ namespace Utilities.Editor.BuildPipeline
 {
     public class MacOSBuildInfo : BuildInfo
     {
+        /// <inheritdoc />
         public override BuildTarget BuildTarget => BuildTarget.StandaloneOSX;
 
+        /// <inheritdoc />
+        public override BuildTargetGroup BuildTargetGroup => BuildTargetGroup.Standalone;
+
+        /// <inheritdoc />
         public override string ExecutableFileExtension => ".app";
 
 #if UNITY_STANDALONE_OSX
 
+        /// <inheritdoc />
         public override string FullOutputPath => UserBuildSettings.createXcodeProject
             ? OutputDirectory
             : base.FullOutputPath;
-
+            
+        /// <inheritdoc />
         public override void ParseCommandLineArgs()
         {
             base.ParseCommandLineArgs();

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -152,7 +152,7 @@ namespace Utilities.Editor.BuildPipeline
 
             // use https://semver.org/
             // major.minor.build
-            Version version = new Version(
+            var version = new Version(
                 (buildInfo.Version == null || buildInfo.AutoIncrement)
                     ? string.IsNullOrWhiteSpace(PlayerSettings.bundleVersion)
                         ? GetValidVersionString(Application.version)
@@ -170,7 +170,7 @@ namespace Utilities.Editor.BuildPipeline
             PlayerSettings.bundleVersion = version.ToString();
             // Update Lumin bc the Application.version isn't synced like Android & iOS
             PlayerSettings.Lumin.versionName = PlayerSettings.bundleVersion;
-            // Update WSA bc the Application.version isn't synced line Android & iOS
+            // Update WSA bc the Application.version isn't synced like Android & iOS
             PlayerSettings.WSA.packageVersion = new Version(version.Major, version.Minor, version.Build, 0);
 
             var buildTargetGroup = UnityEditor.BuildPipeline.GetBuildTargetGroup(buildInfo.BuildTarget);

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- added `BuildTargetGroup` to `IBuildInfo`
- add `dotnetApiCompatibilityLevel` command line arg
- add `scriptingBackend` command line arg
- changed `ignoreCompilerErrors` -> `ignorecompilererrors` to align with unity command line arg