### PR TITLE
com.utilities.buildpipeline 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,17 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
 | `-buildOutputDirectory` | Sets the output directory for the build. |
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
+| `-development` | Sets the build options to build a development build of the player. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
 | `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |
 | `-export` | Creates a native code project for the target platform. |
 | `-symlinkSources` | Enables the use of symbolic links for the sources. |
-| `-disableDebugging` | Disables the ability to attach remote debuggers to the player. |
+| `-disableDebugging` | :warning: deprecated. Use `allowDebugging`. Disables the ability to attach remote debuggers to the player. |
+| `-allowDebugging` | Enables or disables the ability to attache a remote debugger to the player. Can be: `true` or `false`. |
 | `-dotnetApiCompatibilityLevel` | Sets the dotnet api compatibility level of the player. Can be: `NET_2_0`, `NET_2_0_Subset`, `NET_4_6`, `NET_Unity_4_8`, `NET_Web`, `NET_Micro`, `NET_Standard`, or `NET_Standard_2_0`. |
 | `-scriptingBackend` | Sets the scripting framework of the player. Can be: `Mono2x`, `IL2CPP`, or `WinRTDotNET`. |
+| `-autoConnectProfiler` | Start the player with a connection to the profiler. |
+| `-buildWithDeepProfilingSupport` | Enables deep profiling support in the player. |
 
 #### Platform specific Command Line Arguments
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -114,13 +114,17 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
 | `-buildOutputDirectory` | Sets the output directory for the build. |
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
+| `-development` | Sets the build options to build a development build of the player. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
 | `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |
 | `-export` | Creates a native code project for the target platform. |
 | `-symlinkSources` | Enables the use of symbolic links for the sources. |
-| `-disableDebugging` | Disables the ability to attach remote debuggers to the player. |
+| `-disableDebugging` | :warning: deprecated. Use `allowDebugging`. Disables the ability to attach remote debuggers to the player. |
+| `-allowDebugging` | Enables or disables the ability to attache a remote debugger to the player. Can be: `true` or `false`. |
 | `-dotnetApiCompatibilityLevel` | Sets the dotnet api compatibility level of the player. Can be: `NET_2_0`, `NET_2_0_Subset`, `NET_4_6`, `NET_Unity_4_8`, `NET_Web`, `NET_Micro`, `NET_Standard`, or `NET_Standard_2_0`. |
 | `-scriptingBackend` | Sets the scripting framework of the player. Can be: `Mono2x`, `IL2CPP`, or `WinRTDotNET`. |
+| `-autoConnectProfiler` | Start the player with a connection to the profiler. |
+| `-buildWithDeepProfilingSupport` | Enables deep profiling support in the player. |
 
 #### Platform specific Command Line Arguments
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
@@ -206,6 +206,10 @@ namespace Utilities.Editor.BuildPipeline
                     case "-acceptExternalModificationsToPlayer":
                         BuildOptions = BuildOptions.SetFlag(BuildOptions.AcceptExternalModificationsToPlayer);
                         break;
+                    case "-development":
+                        EditorUserBuildSettings.development = true;
+                        BuildOptions = BuildOptions.SetFlag(BuildOptions.Development);
+                        break;
                     case "-colorSpace":
                         ColorSpace = (ColorSpace)Enum.Parse(typeof(ColorSpace), arguments[++i]);
                         break;
@@ -239,6 +243,24 @@ namespace Utilities.Editor.BuildPipeline
                         break;
                     case "-disableDebugging":
                         EditorUserBuildSettings.allowDebugging = false;
+                        Debug.LogWarning("This arg has been deprecated. use \"-allowDebugging false\" instead.");
+                        break;
+                    case "-allowDebugging":
+                        var value = arguments[++i];
+
+                        switch (value.ToLower())
+                        {
+                            case "true":
+                                EditorUserBuildSettings.allowDebugging = true;
+                                break;
+                            case "false":
+                                EditorUserBuildSettings.allowDebugging = false;
+                                break;
+                            default:
+                                Debug.LogError($"Failed to parse -allowDebugging: \"{value}\"");
+                                break;
+                        }
+
                         break;
                     case "-dotnetApiCompatibilityLevel":
                         var apiCompatibilityLevelString = arguments[++i];
@@ -272,6 +294,12 @@ namespace Utilities.Editor.BuildPipeline
                                 break;
                         }
 
+                        break;
+                    case "-autoConnectProfiler":
+                        EditorUserBuildSettings.connectProfiler = true;
+                        break;
+                    case "-buildWithDeepProfilingSupport":
+                        EditorUserBuildSettings.buildWithDeepProfilingSupport = true;
                         break;
                 }
             }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.3.2",
+  "version": "1.3.3",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- added additional command line args `-development`, `-autoConnectProfiler`, and `-buildWithDeepProfilingSupport`
- replaced `-disableDebugging` with `-allowDebugging` which can either be `true` or `false`