### PR TITLE
com.utilities.buildpipeline 1.4.5

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
@@ -1,0 +1,36 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+
+namespace Utilities.Editor.BuildPipeline
+{
+    public class IOSBuildInfo : BuildInfo
+    {
+        public override BuildTarget BuildTarget => BuildTarget.iOS;
+
+        public override BuildTargetGroup BuildTargetGroup => BuildTargetGroup.iOS;
+
+        public override void OnPostProcessBuild(BuildReport report)
+        {
+            if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
+#if PLATFORM_IOS
+#if !UNITY_2021_1_OR_NEWER
+            // https://support.unity.com/hc/en-us/articles/207942813-How-can-I-disable-Bitcode-support
+            var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
+            var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
+            pbxProject.ReadFromFile(projectPath);
+            var target = pbxProject.GetUnityMainTargetGuid();
+            // ReSharper disable once InconsistentNaming
+            const string ENABLE_BITCODE = nameof(ENABLE_BITCODE);
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+            target = pbxProject.TargetGuidByName(UnityEditor.iOS.Xcode.PBXProject.GetUnityTestTargetName());
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+            target = pbxProject.GetUnityFrameworkTargetGuid();
+            pbxProject.SetBuildProperty(target, ENABLE_BITCODE, "NO");
+            pbxProject.WriteToFile(projectPath);
+#endif
+#endif
+        }
+    }
+}

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs.meta
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb94caa1d808ff04f969f3d91c7b457d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -49,12 +49,12 @@ namespace Utilities.Editor.BuildPipeline
                         case BuildTarget.Android:
                             buildInfoInstance = new AndroidBuildInfo();
                             break;
+                        case BuildTarget.iOS:
+                            buildInfoInstance = new IOSBuildInfo();
+                            break;
                         // TODO: Add additional platform specific build info classes as needed
                         //case BuildTarget.StandaloneWindows:
                         //case BuildTarget.StandaloneWindows64:
-                        //    break;
-                        //case BuildTarget.iOS:
-                        //    break;
                         //    break;
                         //case BuildTarget.WebGL:
                         //    break;

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.4.4",
+  "version": "1.4.5",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- added iOSBuildInfo class
- added post process build action to disable unsupported ENABLE_BITCODE since it is no longer supported