### PR TITLE
com.utilities.buildpipeline 1.4.7

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
@@ -15,7 +15,7 @@ namespace Utilities.Editor.BuildPipeline
         {
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
 #if PLATFORM_IOS
-#if !UNITY_2021_1_OR_NEWER
+#if !UNITY_2022_1_OR_NEWER
             // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
             var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
             var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
@@ -25,14 +25,14 @@ namespace Utilities.Editor.BuildPipeline
 #else
             var targetName = PBXProject.GetUnityTargetName();
             var targetGuid = pbxProject.TargetGuidByName(targetName);
-#endif
+#endif // UNITY_2019_3_OR_NEWER
             pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
             pbxProject.WriteToFile(projectPath);
             var projectInString = System.IO.File.ReadAllText(projectPath);
             projectInString = projectInString.Replace("ENABLE_BITCODE = YES;", "ENABLE_BITCODE = NO;");
             System.IO.File.WriteAllText(projectPath, projectInString);
-#endif
-#endif
+#endif // !UNITY_2022_1_OR_NEWER
+#endif // PLATFORM_IOS
         }
     }
 }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.4.6",
+  "version": "1.4.7",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- change IOSBuildInfo compiler symbol to include 2021 for bitcode disabling