### PR TITLE
com.utilities.buildpipeline 1.5.2

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs
@@ -15,22 +15,27 @@ namespace Utilities.Editor.BuildPipeline
         {
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget) { return; }
 #if PLATFORM_IOS
-#if !UNITY_2022_1_OR_NEWER
-            // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
             var projectPath = $"{report.summary.outputPath}/Unity-iPhone.xcodeproj/project.pbxproj";
             var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
             pbxProject.ReadFromFile(projectPath);
 #if UNITY_2019_3_OR_NEWER
-            var targetGuid = pbxProject.GetUnityMainTargetGuid();
+            var mainTargetGuid = pbxProject.GetUnityMainTargetGuid();
 #else
             var targetName = PBXProject.GetUnityTargetName();
-            var targetGuid = pbxProject.TargetGuidByName(targetName);
+            var mainTargetGuid = pbxProject.TargetGuidByName(targetName);
 #endif // UNITY_2019_3_OR_NEWER
-            pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+            // https://discussions.unity.com/t/2019-3-validation-on-upload-to-store-gives-unityframework-framework-contains-disallowed-file/759612/27
+            pbxProject.SetBuildProperty(pbxProject.GetUnityFrameworkTargetGuid(), "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
+            pbxProject.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+#if !UNITY_2022_1_OR_NEWER
+            // https://discussions.unity.com/t/bitcode-bundle-could-not-be-generated-issue/792591/4
+            pbxProject.SetBuildProperty(mainTargetGuid, "ENABLE_BITCODE", "NO");
             pbxProject.WriteToFile(projectPath);
             var projectInString = System.IO.File.ReadAllText(projectPath);
             projectInString = projectInString.Replace("ENABLE_BITCODE = YES;", "ENABLE_BITCODE = NO;");
             System.IO.File.WriteAllText(projectPath, projectInString);
+#else
+            pbxProject.WriteToFile(projectPath);
 #endif // !UNITY_2022_1_OR_NEWER
 #endif // PLATFORM_IOS
         }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.5.1",
+  "version": "1.5.2",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- fix iOS validation when using swift frameworks

## Copilot Summary

This pull request includes changes to improve the iOS build process and update the package version. The most important changes include modifications to the `OnPostProcessBuild` method in `IOSBuildInfo.cs` to handle Swift standard libraries and bitcode settings, and an update to the package version in `package.json`.

### Improvements to iOS Build Process:
* [`Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/IOSBuildInfo.cs`](diffhunk://#diff-693f7ac2a58668190af6c0273485e1aafa8e08fd54ee96e46a5e2f9df9507d9eL18-R38): Modified the `OnPostProcessBuild` method to set `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` for the main target and Unity framework target, and updated the handling of `ENABLE_BITCODE` for different Unity versions.

### Package Version Update:
* [`Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json`](diffhunk://#diff-1bf8683ef5b05ae61aeafadc407894b0756b6409f8d12585eedf92f815487e3eL6-R6): Updated the package version from `1.5.1` to `1.5.2`.