### PR TITLE
com.utilities.buildpipeline 1.5.6

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -23,23 +23,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
-        unity-version: [2019.x, 2020.x, 2021.x, 2022.x, 6000.x]
+        unity-version: [2020.x, 2021.x, 2022.x, 6000.x]
         build-target: [Android]
         include: # for each os specify the build targets
           - os: ubuntu-latest
-            unity-version: 2021.x
+            unity-version: 6000.x
             build-target: StandaloneLinux64
           - os: windows-latest
-            unity-version: 2021.x
+            unity-version: 6000.x
             build-target: StandaloneWindows64
           - os: windows-latest
-            unity-version: 2021.x
+            unity-version: 6000.x
             build-target: WSAPlayer
-          - os: macos-13
-            unity-version: 2021.x
+          - os: macos-15
+            unity-version: 6000.x
             build-target: iOS
-          - os: macos-13
-            unity-version: 2021.x
+          - os: macos-15
+            unity-version: 6000.x
             build-target: StandaloneOSX
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,6 @@ jobs:
         with:
           unity-version: ${{ matrix.unity-version }}
           build-targets: ${{ matrix.build-target }}
-
         # Activates the installation with the provided credentials
       - uses: RageAgainstThePixel/activate-unity-license@v1
         with:
@@ -60,7 +59,6 @@ jobs:
           username: ${{ secrets.UNITY_USERNAME }}
           password: ${{ secrets.UNITY_PASSWORD }}
           # serial: ${{ secrets.UNITY_SERIAL }} # Required for pro activations
-
       - name: Unity Build (${{ matrix.build-target }})
         uses: RageAgainstThePixel/unity-build@main
         with:
@@ -71,7 +69,6 @@ jobs:
           publish-artifacts: true
           artifact-name: '${{ github.run_number }}.${{ github.run_attempt }}-${{ matrix.os }}-${{ matrix.unity-version }}-${{ matrix.build-target }}-Artifacts'
           test: false
-
       - name: Validate Text Mesh Pro Resources
         if: ${{ matrix.unity-version != '6000.x' }}
         run: |

--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
         unity-version: [2020.x, 2021.x, 2022.x, 6000.x]
         build-target: [Android]
         include: # for each os specify the build targets

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 
 | Argument | Description |
 | -------- | ----------- |
+| `-appBundle` | Builds an .abb for Google Play Store |
 | `-splitBinary` | Builds an APK per CPU architecture. |
 | `-splitApk` | Uses APK expansion files. |
 | `-keystorePath` | Path to the keystore. |

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
@@ -34,6 +34,9 @@ namespace Utilities.Editor.BuildPipeline
             {
                 switch (arguments[i])
                 {
+                    case "-appBundle":
+                        EditorUserBuildSettings.buildAppBundle = true;
+                        break;
                     case "-splitBinary":
                         PlayerSettings.Android.buildApkPerCpuArchitecture = true;
                         break;
@@ -103,7 +106,7 @@ namespace Utilities.Editor.BuildPipeline
 
             if (Application.isBatchMode)
             {
-                // Disable to prevent gradle form killing parallel builds
+                // Disable to prevent gradle form killing parallel builds on same build machine
                 EditorPrefs.SetBool("AndroidGradleStopDaemonsOnExit", false);
             }
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.5.5",
+  "version": "1.5.6",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- add `-appBundle` arg for Android abb google play bundles
- updated workflows to only test latest 6000.x and dropped 2019x