### PR TITLE
com.utilities.buildpipeline 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-ignoreCompilerErrors` | Disables logging. |
 | `-autoIncrement` | Enables auto incrementing. |
 | `-versionName` | Sets the version of the application. Value must be string. |
-| `-versionCode` | Sets the version code of the application. Value must be an integer. |
+| `-buildNumber` | Sets the version build number of the application. (For Android, this must be an integer.) |
 | `-bundleIdentifier` | Sets the bundle identifier of the application. |
 | `-sceneList` | Sets the scenes of the application, list as CSV. |
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
@@ -178,6 +178,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-keyaliasName` | Name of the key to use when signing. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
+| `-versionCode` | Sets the version code of the application. Must be an integer. |
 
 ##### Apple Device Command Line Args
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ jobs:
     strategy:
       # max-parallel: 2 # Use this if you're activating pro license with matrix
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
-        unity-version: [2019.x, 2020.x, 2021.x, 2022.x, 6000.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        unity-versions: [2019.x, 2020.x, 2021.x, 2022.x, 6000.x]
         include: # for each os specify the build targets
           - os: ubuntu-latest
             build-target: StandaloneLinux64
           - os: windows-latest
             build-target: StandaloneWindows64
-          - os: macos-13
+          - os: macos-latest
             build-target: StandaloneOSX
 
     steps:
@@ -90,7 +90,7 @@ jobs:
         # sets -> env.UNITY_PROJECT_PATH
       - uses: RageAgainstThePixel/unity-setup@v1
         with:
-          unity-version: ${{ matrix.unity-version }}
+          unity-version: ${{ matrix.unity-versions }}
           build-targets: ${{ matrix.build-target }}
 
         # Activates the installation with the provided credentials

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-keyaliasName` | Name of the key to use when signing. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
-| `-versionCode` | Sets the version code of the application. Must be an integer. |
+| `-versionCode` | Sets the version code of the application. Must be an integer. ***Deprecated, use `versionNumber` instead*** |
 
 ##### Apple Device Command Line Args
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -143,7 +143,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-ignoreCompilerErrors` | Disables logging. |
 | `-autoIncrement` | Enables auto incrementing. |
 | `-versionName` | Sets the version of the application. Value must be string. |
-| `-versionCode` | Sets the version code of the application. Value must be an integer. |
+| `-buildNumber` | Sets the version build number of the application. (For Android, this must be an integer.) |
 | `-bundleIdentifier` | Sets the bundle identifier of the application. |
 | `-sceneList` | Sets the scenes of the application, list as CSV. |
 | `-sceneListFile` | Sets the scenes of the application, list as JSON. |
@@ -151,7 +151,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
 | `-development` | Sets the build options to build a development build of the player. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
-| `-textureCompression` | Set the build texture compression. Can be: `LZ4`, `LZ4HC` |
+| `-compressionMethod` | Set the build compression. Can be: `LZ4`, `LZ4HC` |
 | `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |
 | `-export` | Creates a native code project for the target platform. |
 | `-symlinkSources` | Enables the use of symbolic links for the sources. |
@@ -170,6 +170,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 
 | Argument | Description |
 | -------- | ----------- |
+| `-appBundle` | Builds an .abb for Google Play Store |
 | `-splitBinary` | Builds an APK per CPU architecture. |
 | `-splitApk` | Uses APK expansion files. |
 | `-keystorePath` | Path to the keystore. |
@@ -177,6 +178,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-keyaliasName` | Name of the key to use when signing. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
+| `-versionCode` | Sets the version code of the application. Must be an integer. |
 
 ##### Apple Device Command Line Args
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -72,14 +72,14 @@ jobs:
     strategy:
       # max-parallel: 2 # Use this if you're activating pro license with matrix
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         unity-versions: [2019.x, 2020.x, 2021.x, 2022.x, 6000.x]
         include: # for each os specify the build targets
           - os: ubuntu-latest
             build-target: StandaloneLinux64
           - os: windows-latest
             build-target: StandaloneWindows64
-          - os: macos-13
+          - os: macos-latest
             build-target: StandaloneOSX
 
     steps:

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -178,7 +178,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-keyaliasName` | Name of the key to use when signing. |
 | `-keyaliasPass` | Sets the key alias password. |
 | `-symbols` | Sets the symbol creation mode. Can be: `public`, `debugging`, or `disabled`. |
-| `-versionCode` | Sets the version code of the application. Must be an integer. |
+| `-versionCode` | Sets the version code of the application. Must be an integer. ***Deprecated, use `versionNumber` instead*** |
 
 ##### Apple Device Command Line Args
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
@@ -44,7 +44,7 @@ namespace Utilities.Editor.BuildPipeline
         public virtual Version Version { get; set; }
 
         /// <inheritdoc />
-        public int? VersionCode { get; set; }
+        public virtual string BuildNumber { get; set; } = null;
 
         /// <inheritdoc />
         public virtual BuildTarget BuildTarget { get; } = EditorUserBuildSettings.activeBuildTarget;
@@ -189,15 +189,8 @@ namespace Utilities.Editor.BuildPipeline
                             Debug.LogError($"Failed to parse -versionName \"{arguments[i]}\"");
                         }
                         break;
-                    case "-versionCode":
-                        if (int.TryParse(arguments[++i], out var versionCode))
-                        {
-                            VersionCode = versionCode;
-                        }
-                        else
-                        {
-                            Debug.LogError($"Failed to parse -versionCode \"{arguments[i]}\"");
-                        }
+                    case "-buildNumber":
+                        BuildNumber = arguments[++i];
                         break;
                     case "-bundleIdentifier":
                         BundleIdentifier = arguments[++i];

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/IBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/IBuildInfo.cs
@@ -27,7 +27,7 @@ namespace Utilities.Editor.BuildPipeline
         string BundleIdentifier { get; set; }
 
         /// <summary>
-        /// The build version number
+        /// The build version number.
         /// </summary>
         /// <remarks>
         /// If set will override <see cref="AutoIncrement"/>
@@ -35,9 +35,9 @@ namespace Utilities.Editor.BuildPipeline
         Version Version { get; set; }
 
         /// <summary>
-        /// The version code (usually a single integer for platforms like iOS, and Android).
+        /// The build version number.
         /// </summary>
-        int? VersionCode { get; set; }
+        string BuildNumber { get; set; }
 
         /// <summary>
         /// Is this build being issued from the command line?

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Platforms/AndroidBuildInfo.cs
@@ -92,6 +92,9 @@ namespace Utilities.Editor.BuildPipeline
 #pragma warning restore CS0618 // Type or member is obsolete
 #endif // UNITY_6000_0_OR_NEWER
                         break;
+                    case "-versionCode":
+                        BuildNumber = arguments[++i];
+                        break;
                 }
             }
 
@@ -115,22 +118,6 @@ namespace Utilities.Editor.BuildPipeline
             {
                 // Disable to prevent gradle form killing parallel builds on same build machine
                 EditorPrefs.SetBool("AndroidGradleStopDaemonsOnExit", false);
-            }
-
-            if (VersionCode.HasValue)
-            {
-                PlayerSettings.Android.bundleVersionCode = VersionCode.Value;
-            }
-            else if (AutoIncrement)
-            {
-                // Usually version codes are unique and not tied to the usual semver versions
-                // see https://developer.android.com/studio/publish/versioning#appversioning
-                // versionCode - A positive integer used as an internal version number.
-                // This number is used only to determine whether one version is more recent than another,
-                // with higher numbers indicating more recent versions. The Android system uses the
-                // versionCode value to protect against downgrades by preventing users from installing
-                // an APK with a lower versionCode than the version currently installed on their device.
-                PlayerSettings.Android.bundleVersionCode++;
             }
         }
     }

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -146,9 +146,35 @@ namespace Utilities.Editor.BuildPipeline
             PlayerSettings.Lumin.versionName = PlayerSettings.bundleVersion;
             // Update WSA bc the Application.version isn't synced like Android & iOS
             PlayerSettings.WSA.packageVersion = new Version(version.Major, version.Minor, version.Build, 0);
-#if UNITY_2023_3_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             PlayerSettings.visionOSBundleVersion = PlayerSettings.bundleVersion;
 #endif // UNITY_2023_3_OR_NEWER
+
+            // set build number
+            if (!string.IsNullOrWhiteSpace(buildInfo.BuildNumber))
+            {
+#if PLATFORM_ANDROID
+                if (int.TryParse(buildInfo.BuildNumber, out var code))
+                {
+                    PlayerSettings.Android.bundleVersionCode = code;
+                }
+                else
+                {
+                    Debug.LogError($"Failed to parse versionCode \"{BuildNumber}\"");
+                }
+            }
+            else if (buildInfo.AutoIncrement)
+            {
+                PlayerSettings.Android.bundleVersionCode++;
+#else
+                PlayerSettings.iOS.buildNumber = buildInfo.BuildNumber;
+                PlayerSettings.macOS.buildNumber = buildInfo.BuildNumber;
+                PlayerSettings.tvOS.buildNumber = buildInfo.BuildNumber;
+#if UNITY_2022_3_OR_NEWER
+                PlayerSettings.VisionOS.buildNumber = buildInfo.BuildNumber;
+#endif // UNITY_2022_3_OR_NEWER
+#endif // PLATFORM_ANDROID
+            }
 
             var buildTargetGroup = UnityEditor.BuildPipeline.GetBuildTargetGroup(buildInfo.BuildTarget);
 #if UNITY_2023_1_OR_NEWER

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -160,7 +160,7 @@ namespace Utilities.Editor.BuildPipeline
                 }
                 else
                 {
-                    Debug.LogError($"Failed to parse versionCode \"{BuildNumber}\"");
+                    Debug.LogError($"Failed to parse versionCode \"{buildInfo.BuildNumber}\"");
                 }
             }
             else if (buildInfo.AutoIncrement)

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.6.1",
+  "version": "1.6.2",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- properly set iOS/macOS/tvOS build numbers
- added new buildNumber arg that can be used for Android and Apple platforms
  - kept versionCode for Android but can be used interchangeably for easier to build workflows