### PR TITLE
com.utilities.buildpipeline 1.7.4

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/UnityPlayerBuildTools.cs
@@ -147,7 +147,7 @@ namespace Utilities.Editor.BuildPipeline
                         case BuildResult.Cancelled:
                         default:
                             Debug.LogError($"{message}"
-#if UNITY_2022_1_OR_NEWER
+#if UNITY_2023_1_OR_NEWER
                                            + $"{buildReport.SummarizeErrors()}"
 #endif
                             );

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.7.3",
+  "version": "1.7.4",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- fix compiler error when generating build summary for 2022.3 LTS