### PR TITLE
com.utilities.buildpipeline 1.7.6

### DIFF
--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Logging/CILoggingUtility.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/Logging/CILoggingUtility.cs
@@ -53,7 +53,8 @@ namespace Utilities.Editor.BuildPipeline.Logging
             @"Reference rewriter: Error: method `System.Numerics.Vector3[] Windows.Perception.Spatial.SpatialStageFrameOfReference::TryGetMovementBounds(Windows.Perception.Spatial.SpatialCoordinateSystem)` doesn't exist in target framework. It is referenced from XRTK.WindowsMixedReality.dll at System.Boolean XRTK.WindowsMixedReality.Providers.BoundarySystem.WindowsMixedRealityBoundaryDataProvider::TryGetBoundaryGeometry",
             @"Selected Visual Studio is missing required components and may not be able to build the generated project. You can install the missing Visual Studio components by opening the generated project in Visual Studio.",
             @"GfxDevice renderer is null. Unity cannot update the Ambient Probe and Reflection Probes that the SkyManager generates. Run the Editor without the -nographics argument or generate lighting for your scene.",
-            @"Light baking could not be started because no valid OpenCL device could be found."
+            @"Light baking could not be started because no valid OpenCL device could be found.",
+            @"OpenCL Error: 'clGetPlatformIDs(kMaxPlatforms, platforms, &numPlatforms)' returned -1001 (CL_PLATFORM_NOT_FOUND_KHR)."
         };
 
         static CILoggingUtility()

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.7.5",
+  "version": "1.7.6",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",


### PR DESCRIPTION
- added additional ignored line: "OpenCL Error: 'clGetPlatformIDs(kMaxPlatforms, platforms, &numPlatforms)' returned -1001 (CL_PLATFORM_NOT_FOUND_KHR)."