### PR TITLE
com.utilities.buildpipeline 1.7.8

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -3,13 +3,11 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday at midnight
   push:
-    branches:
-      - 'main'
+    branches: [main]
   pull_request:
-    branches:
-      - '**'
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: ['**']
+  workflow_dispatch: # manual workflow trigger
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{(github.event_name == 'pull_request' || github.event.action == 'synchronize')}}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Build Pipeline utility package for the [Unity](https://unity.com/) Game Engine
 
 Requires Unity 2019.4 LTS or higher.
 
-The recommended installation method is though the unity package manager and [OpenUPM](https://openupm.com/packages/com.utilities.buildpipeine).
+The recommended installation method is though the unity package manager and [OpenUPM](https://openupm.com/packages/com.utilities.buildpipeline).
 
 ### Via Unity Package Manager and OpenUPM
 
@@ -36,7 +36,7 @@ openupm add com.utilities.buildpipeline
 ### Via Unity Package Manager and Git url
 
 - Open your Unity Package Manager
-- Add package from git url: `https://github.com/RageAgainstThePixel/com.utilities.buildpipeine.git#upm`
+- Add package from git url: `https://github.com/RageAgainstThePixel/com.utilities.buildpipeline.git#upm`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ In addition to any already defined [Unity Editor command line arguments](https:/
 | `-buildOutputDirectory` | Sets the output directory for the build. |
 | `-acceptExternalModificationsToPlayer` | Sets the build options to accept external modifications to the player. |
 | `-development` | Sets the build options to build a development build of the player. |
+| `-patch` | Sets the build options to build a patch of the player for platforms that support it. |
 | `-colorSpace` | Sets the color space of the application, if the provided color space string is a valid `ColorSpace` enum value. |
 | `-compressionMethod` | Set the build compression. Can be: `LZ4`, `LZ4HC` |
 | `-buildConfiguration` | Sets the build configuration of the application. Can be:  `debug`, `master`, or `release`. |

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Documentation~/README.md
@@ -36,7 +36,7 @@ openupm add com.utilities.buildpipeline
 ### Via Unity Package Manager and Git url
 
 - Open your Unity Package Manager
-- Add package from git url: `https://github.com/RageAgainstThePixel/com.utilities.buildpipeine.git#upm`
+- Add package from git url: `https://github.com/RageAgainstThePixel/com.utilities.buildpipeline.git#upm`
 
 ## Documentation
 

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/Editor/BuildInfo.cs
@@ -211,6 +211,9 @@ namespace Utilities.Editor.BuildPipeline
                         EditorUserBuildSettings.development = true;
                         BuildOptions = BuildOptions.SetFlag(BuildOptions.Development);
                         break;
+                    case "-patch":
+                        BuildOptions = BuildOptions.SetFlag(BuildOptions.PatchPackage);
+                        break;
                     case "-colorSpace":
                         ColorSpace = (ColorSpace)Enum.Parse(typeof(ColorSpace), arguments[++i]);
                         break;

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.BuildPipeline",
   "description": "The Build Pipeline Utilities aims to give developers more tools and options when making builds with the command line or with continuous integration.",
   "keywords": [],
-  "version": "1.7.7",
+  "version": "1.7.8",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",

--- a/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
+++ b/Utilities.BuildPipeline/Packages/com.utilities.buildpipeline/package.json
@@ -5,12 +5,12 @@
   "keywords": [],
   "version": "1.7.8",
   "unity": "2019.4",
-  "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine#documentation",
-  "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeine/releases",
+  "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeline#documentation",
+  "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.buildpipeline/releases",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RageAgainstThePixel/com.utilities.buildpipeine.git"
+    "url": "git+https://github.com/RageAgainstThePixel/com.utilities.buildpipeline.git"
   },
   "author": {
     "name": "Stephen Hodgson",


### PR DESCRIPTION
- add `-patch` arg to patch development builds for platforms that support it.